### PR TITLE
Add ensemble learners algorithm

### DIFF
--- a/algorithms/linfa-ensemble/Cargo.toml
+++ b/algorithms/linfa-ensemble/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "linfa-ensemble"
+version = "0.5.0"
+edition = "2018"
+authors = ["James Knight <j.knight21@ucl.ac.uk>"]
+description = "A collection of simple ensemble learning algorithms"
+license = "MIT/Apache-2.0"
+
+repository = "https://github.com/rust-ml/linfa"
+readme = "README.md"
+
+keywords = ["machine-learning", "linfa", "ensemble"]
+categories = ["algorithms", "mathematics", "science"]
+
+[features]
+default = []
+serde = ["serde_crate", "ndarray/serde"]
+
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0"
+default-features = false
+features = ["std", "derive"]
+
+[dependencies]
+ndarray = { version = "0.15" , features = ["rayon", "approx"]}
+ndarray-rand = "0.14"
+rand = "0.8.5"
+
+linfa = { version = "0.5.0", path = "../.." }
+linfa-trees = { version = "0.5.0", path = "../linfa-trees"}
+
+[dev-dependencies]
+linfa-datasets = { version = "0.5.0", path = "../../datasets/", features = ["iris"] }
+

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -8,10 +8,13 @@ use ndarray::{
     Array1, Array2, ArrayBase, Axis,
     Data, Ix2,
 };
-use std::collections::HashMap;
+use std::{
+    cmp::Eq,
+    collections::HashMap,
+    hash::Hash,
+};
 
 // Add a wrapper function for getting stats out of predictors
-// Want to remove T here, but it causes unconstrained parameter error in impl block below
 pub struct EnsembleLearner<M> {
     pub models: Vec<M>,
 }
@@ -31,7 +34,7 @@ impl<M> EnsembleLearner<M> {
     -> Array1<Vec<(Array1<<Ys::Item as AsTargets>::Elem>, usize)>>
     where
         Ys::Item: AsTargets,
-        <Ys::Item as AsTargets>::Elem: Copy + std::cmp::Eq + std::hash::Hash,
+        <Ys::Item as AsTargets>::Elem: Copy + Eq + Hash,
     {
         let mut prediction_maps = Vec::new();
 
@@ -66,7 +69,7 @@ impl<F: Clone, T, M>
 PredictInplace<Array2<F>, T> for EnsembleLearner<M>
 where
     M: PredictInplace<Array2<F>, T>,
-    <T as AsTargets>::Elem: Copy + std::cmp::Eq + std::hash::Hash,
+    <T as AsTargets>::Elem: Copy + Eq + Hash,
     T: AsTargets + AsTargetsMut<Elem = <T as AsTargets>::Elem>,
 {
     fn predict_inplace(&self, x: &Array2<F>, y: &mut T) {
@@ -117,7 +120,7 @@ impl<P> EnsembleLearnerParams<P> {
         self
     }
 
-    pub fn model_params(&mut self, params: P) -> &mut EnsembleLearnerParams<P>  {
+    pub fn model_params(&mut self, params: P) -> &mut EnsembleLearnerParams<P> {
         self.model_params = Some(params);
         self
     }
@@ -129,7 +132,7 @@ where
     D: Data,
     D::Elem: Clone,
     T: AsTargets + FromTargetArrayOwned<<T as AsTargets>::Elem>,
-    <T as AsTargets>::Elem: Copy + std::cmp::Eq + std::hash::Hash,
+    <T as AsTargets>::Elem: Copy + Eq + Hash,
     T::Owned: AsTargets,
 {
     type Object = EnsembleLearner<P::Object>;

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -18,13 +18,13 @@ pub struct EnsembleLearner<F, E, M, T> {
     _t: PhantomData<(F, E, T)>
 }
 
-impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>> EnsembleLearner<F, E, M, T>
+impl <F: Clone, E, T, M: PredictInplace<Array2<F>, T>> EnsembleLearner<F, E, M, T>
 where
-    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
+    E: Copy + std::cmp::Eq + std::hash::Hash,
     T: AsTargets<Elem = E>,
 {
 
-    pub fn generate_predictions(&'b self, x: &'b Array2<F>) -> impl Iterator<Item = T> + 'b {
+    pub fn generate_predictions<'b>(&'b self, x: &'b Array2<F>) -> impl Iterator<Item = T> + 'b {
         self.models.iter().map(move |m| {
             let result = m.predict(x);
             result
@@ -34,7 +34,7 @@ where
 
     // Consumes prediction iterator to return all predictions made by any model
     // Orders predictions by total number of models giving that prediciton
-    pub fn aggregate_predictions(&self, ys: impl Iterator<Item=T> + 'b)
+    pub fn aggregate_predictions(&self, ys: impl Iterator<Item=T>)
     -> Array1<Vec<(Array1<E>, usize)>>
     {
         let mut prediction_maps = Vec::new();

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -1,0 +1,182 @@
+use linfa::{
+    dataset::{AsTargets, AsTargetsMut, FromTargetArray},
+    error::{Error},
+    traits::*,
+    DatasetBase,
+};
+use ndarray::{
+    Array1, Array2, ArrayBase, Axis,
+    Data, Ix2, 
+};
+use std::marker::PhantomData;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+//Add a wrapper function for getting stats out of predictors
+//Want to remove T here, but it causes unconstrained parameter error in impl block below
+pub struct EnsembleLearner<F, E, M, T> {
+    pub models: Vec<M>,
+    _t: PhantomData<(F, E, T)>
+}
+
+impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>> EnsembleLearner<F, E, M, T>
+where
+    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
+    T: AsTargets<Elem = E>,
+{
+
+    pub fn generate_predictions(&'b self, x: &'b Array2<F>) -> impl Iterator<Item = T> + 'b {
+        self.models.iter().map(move |m| {
+            let result = m.predict(x);
+            result
+        })
+    }
+
+
+    //Consumes prediction iterator to return all predictions made by any model 
+    //Orders predictions by total number of models giving that prediciton
+    pub fn aggregate_predictions<I>(&self, ys: I) -> Array1<Vec<(Array1<E>, usize)>> 
+    where
+        I: Iterator<Item = T> + 'b
+    {
+
+        let mut prediction_maps = Vec::new();
+
+        for y in ys {
+            
+            let targets = y.as_multi_targets();
+            let no_targets = targets.shape()[0];
+
+            for i in 0..no_targets {
+                if prediction_maps.len() == i {
+                    prediction_maps.push(HashMap::new())
+                }
+                //Still need to take ownership here to get data out of view
+                //Might be better to store all predictions elsewhere and return a view on them here?
+                *prediction_maps[i].entry(y.as_multi_targets().index_axis(Axis(0), i).to_owned()).or_insert(0) += 1;
+            }
+
+        }
+
+        let mut prediction_array = Array1::from_elem(prediction_maps.len(), Vec::new());
+
+        for i in 0..prediction_maps.len() {
+            //I think these need to copy data again and would also be nicer if they contained a view?
+            prediction_array[i] = prediction_maps[i].to_owned().into_iter().collect();
+            prediction_array[i].sort_by(|(_, a), (_, b)| b.cmp(a))
+
+        }
+
+
+        prediction_array        
+        
+    }
+
+}
+
+impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>> 
+PredictInplace<Array2<F>, T> for EnsembleLearner<F, E, M, T>
+where
+    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
+    T: AsTargets<Elem = E> + AsTargetsMut<Elem = E> + FromTargetArray<'b, E>,
+{
+    fn predict_inplace(&self, x: &Array2<F>, y: &mut T) {
+        let mut y_array = y.as_multi_targets_mut();
+        assert_eq!(
+            x.nrows(),
+            y_array.len(),
+            "The number of data points must match the number of output targets."
+        );
+
+        let mut predictions = self.generate_predictions(x);
+        let aggregated_predictions = self.aggregate_predictions(&mut predictions);
+
+        for (target, output) in y_array.axis_iter_mut(Axis(0)).zip(aggregated_predictions.into_iter()) {
+            for (t, o) in target.into_iter().zip(output[0].0.iter()) {
+                *t = *o;
+            }
+        }
+    }
+
+    fn default_target(&self, x: &Array2<F>) -> T{
+        self.models[0].default_target(x)
+    }
+}
+
+pub struct EnsembleLearnerParams<F, E, P> {
+    pub ensemble_size: usize,
+    pub bootstrap_proportion: f64,
+    pub model_params: Option<P>,
+    _t: PhantomData<(F, E)>
+
+}
+
+impl<F, E, P> EnsembleLearnerParams<F, E, P> {
+
+    pub fn new() -> EnsembleLearnerParams<F, E, P> {
+        EnsembleLearnerParams {ensemble_size: 1, bootstrap_proportion: 1.0, model_params: None, _t: PhantomData}
+    }
+
+    pub fn ensemble_size(&mut self, size: usize) -> &mut EnsembleLearnerParams<F, E, P> {
+        self.ensemble_size = size;
+        self
+    }
+
+    pub fn bootstrap_proportion(&mut self, proportion: f64) -> &mut EnsembleLearnerParams<F, E, P> {
+        self.bootstrap_proportion = proportion;
+        self
+    }
+
+    pub fn model_params(&mut self, params: P) -> &mut EnsembleLearnerParams<F, E, P>  {
+        self.model_params = Some(params);
+        self
+    }
+} 
+
+//T::Owned=T is a hack to make the bootstrapped samples fittable which only works for Array2
+//Instead, for a general solution, we would like to write:
+// - P: Fit<Array2<F>, T::Owned, Error>
+// - type Object = EnsembleLearner<F, E, P::Object, T::Owned>;
+//But this won't compile as it makes 'b unconstrained for some reason
+impl<'b, F: Clone, E, D, T, P: Fit<Array2<F>, T, Error>> 
+     Fit<ArrayBase<D, Ix2>, T, Error> for EnsembleLearnerParams<F, E, P>
+where
+    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
+    D: Data<Elem = F> ,
+    T: AsTargets<Elem = E> + FromTargetArray<'b, E, Owned=T>, 
+    T::Owned: AsTargets
+{
+    type Object = EnsembleLearner<F, E, P::Object, T>;
+
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> std::result::Result<Self::Object, Error> {
+        
+        assert!(
+            !self.model_params.is_none(),
+            "Must define an underlying model for ensemble learner"
+        );
+
+        let mut models = Vec::new();
+        let rng =  &mut rand::thread_rng();
+
+        let dataset_size = ((dataset.records.shape()[0] as f64) * self.bootstrap_proportion) as usize;
+
+        //Had to modify lifetimes in impl_dataset to get this to work!
+        let iter = dataset.bootstrap_samples(dataset_size,rng);
+        
+        let mut i = 0;
+        for train in iter {
+            println!("Fitting model {}, {}", i, dataset_size);
+            i += 1;
+            let model = self.model_params.as_ref().unwrap().fit(&train).unwrap();
+            models.push(model);
+            if models.len() == self.ensemble_size {
+                break
+            }
+        }
+        
+        Ok(EnsembleLearner{models:models, 
+                           _t: PhantomData {}})
+
+    }
+}
+

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -1,19 +1,18 @@
 use linfa::{
-    dataset::{AsTargets, AsTargetsMut, FromTargetArray},
+    dataset::{AsTargets, AsTargetsMut, FromTargetArray, FromTargetArrayOwned},
     error::{Error},
     traits::*,
     DatasetBase,
 };
 use ndarray::{
     Array1, Array2, ArrayBase, Axis,
-    Data, Ix2, 
+    Data, Ix2,
 };
 use std::marker::PhantomData;
 use std::collections::HashMap;
-use std::iter::FromIterator;
 
-//Add a wrapper function for getting stats out of predictors
-//Want to remove T here, but it causes unconstrained parameter error in impl block below
+// Add a wrapper function for getting stats out of predictors
+// Want to remove T here, but it causes unconstrained parameter error in impl block below
 pub struct EnsembleLearner<F, E, M, T> {
     pub models: Vec<M>,
     _t: PhantomData<(F, E, T)>
@@ -33,17 +32,14 @@ where
     }
 
 
-    //Consumes prediction iterator to return all predictions made by any model 
-    //Orders predictions by total number of models giving that prediciton
-    pub fn aggregate_predictions<I>(&self, ys: I) -> Array1<Vec<(Array1<E>, usize)>> 
-    where
-        I: Iterator<Item = T> + 'b
+    // Consumes prediction iterator to return all predictions made by any model
+    // Orders predictions by total number of models giving that prediciton
+    pub fn aggregate_predictions(&self, ys: impl Iterator<Item=T> + 'b)
+    -> Array1<Vec<(Array1<E>, usize)>>
     {
-
         let mut prediction_maps = Vec::new();
 
         for y in ys {
-            
             let targets = y.as_multi_targets();
             let no_targets = targets.shape()[0];
 
@@ -68,13 +64,13 @@ where
         }
 
 
-        prediction_array        
-        
+        prediction_array
+
     }
 
 }
 
-impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>> 
+impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>>
 PredictInplace<Array2<F>, T> for EnsembleLearner<F, E, M, T>
 where
     E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
@@ -112,7 +108,6 @@ pub struct EnsembleLearnerParams<F, E, P> {
 }
 
 impl<F, E, P> EnsembleLearnerParams<F, E, P> {
-
     pub fn new() -> EnsembleLearnerParams<F, E, P> {
         EnsembleLearnerParams {ensemble_size: 1, bootstrap_proportion: 1.0, model_params: None, _t: PhantomData}
     }
@@ -131,28 +126,22 @@ impl<F, E, P> EnsembleLearnerParams<F, E, P> {
         self.model_params = Some(params);
         self
     }
-} 
+}
 
-//T::Owned=T is a hack to make the bootstrapped samples fittable which only works for Array2
-//Instead, for a general solution, we would like to write:
-// - P: Fit<Array2<F>, T::Owned, Error>
-// - type Object = EnsembleLearner<F, E, P::Object, T::Owned>;
-//But this won't compile as it makes 'b unconstrained for some reason
-impl<'b, F: Clone, E, D, T, P: Fit<Array2<F>, T, Error>> 
+impl<F: Clone, E, D, T, P: Fit<Array2<F>, T::Owned, Error>>
      Fit<ArrayBase<D, Ix2>, T, Error> for EnsembleLearnerParams<F, E, P>
 where
-    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
+    E: Copy + std::cmp::Eq + std::hash::Hash,
     D: Data<Elem = F> ,
-    T: AsTargets<Elem = E> + FromTargetArray<'b, E, Owned=T>, 
-    T::Owned: AsTargets
+    T: AsTargets<Elem = E> + FromTargetArrayOwned<E>,
+    T::Owned: AsTargets,
 {
-    type Object = EnsembleLearner<F, E, P::Object, T>;
+    type Object = EnsembleLearner<F, E, P::Object, T::Owned>;
 
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> std::result::Result<Self::Object, Error> {
-        
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object, Error> {
         assert!(
-            !self.model_params.is_none(),
-            "Must define an underlying model for ensemble learner"
+            self.model_params.is_some(),
+            "Must define an underlying model for ensemble learner",
         );
 
         let mut models = Vec::new();
@@ -161,8 +150,8 @@ where
         let dataset_size = ((dataset.records.shape()[0] as f64) * self.bootstrap_proportion) as usize;
 
         //Had to modify lifetimes in impl_dataset to get this to work!
-        let iter = dataset.bootstrap_samples(dataset_size,rng);
-        
+        let iter = dataset.bootstrap_samples(dataset_size, rng);
+
         let mut i = 0;
         for train in iter {
             println!("Fitting model {}, {}", i, dataset_size);
@@ -173,10 +162,9 @@ where
                 break
             }
         }
-        
-        Ok(EnsembleLearner{models:models, 
+
+        Ok(EnsembleLearner{models:models,
                            _t: PhantomData {}})
 
     }
 }
-

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -13,12 +13,12 @@ use std::collections::HashMap;
 
 // Add a wrapper function for getting stats out of predictors
 // Want to remove T here, but it causes unconstrained parameter error in impl block below
-pub struct EnsembleLearner<F, E, M, T> {
+pub struct EnsembleLearner<F, M, T> {
     pub models: Vec<M>,
-    _t: PhantomData<(F, E, T)>
+    _t: PhantomData<(F, T)>,
 }
 
-impl <F: Clone, T, M: PredictInplace<Array2<F>, T>> EnsembleLearner<F, T::Elem, M, T>
+impl <F: Clone, T, M: PredictInplace<Array2<F>, T>> EnsembleLearner<F, M, T>
 where
     T: AsTargets,
     T::Elem: Copy + std::cmp::Eq + std::hash::Hash,
@@ -66,7 +66,7 @@ where
 }
 
 impl <F: Clone, T, M: PredictInplace<Array2<F>, T>>
-PredictInplace<Array2<F>, T> for EnsembleLearner<F, <T as AsTargets>::Elem, M, T>
+PredictInplace<Array2<F>, T> for EnsembleLearner<F, M, T>
 where
     <T as AsTargets>::Elem: Copy + std::cmp::Eq + std::hash::Hash,
     T: AsTargets + AsTargetsMut<Elem = <T as AsTargets>::Elem>,
@@ -131,7 +131,7 @@ where
     <T as AsTargets>::Elem: Copy + std::cmp::Eq + std::hash::Hash,
     T::Owned: AsTargets,
 {
-    type Object = EnsembleLearner<F, <T as AsTargets>::Elem, P::Object, T::Owned>;
+    type Object = EnsembleLearner<F, P::Object, T::Owned>;
 
     fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object, Error> {
         assert!(

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -1,5 +1,5 @@
 use linfa::{
-    dataset::{AsTargets, AsTargetsMut, FromTargetArray, FromTargetArrayOwned},
+    dataset::{AsTargets, AsTargetsMut, FromTargetArrayOwned},
     error::{Error},
     traits::*,
     DatasetBase,
@@ -70,11 +70,11 @@ where
 
 }
 
-impl <'b, F: Clone, E, T, M: PredictInplace<Array2<F>, T>>
+impl <F: Clone, E, T, M: PredictInplace<Array2<F>, T>>
 PredictInplace<Array2<F>, T> for EnsembleLearner<F, E, M, T>
 where
-    E: Copy + std::cmp::Eq + std::hash::Hash + 'b,
-    T: AsTargets<Elem = E> + AsTargetsMut<Elem = E> + FromTargetArray<'b, E>,
+    E: Copy + std::cmp::Eq + std::hash::Hash,
+    T: AsTargets<Elem = E> + AsTargetsMut<Elem = E>,
 {
     fn predict_inplace(&self, x: &Array2<F>, y: &mut T) {
         let mut y_array = y.as_multi_targets_mut();
@@ -128,6 +128,11 @@ impl<F, E, P> EnsembleLearnerParams<F, E, P> {
     }
 }
 
+//T::Owned=T is a hack to make the bootstrapped samples fittable which only works for Array2
+//Instead, for a general solution, we would like to write:
+// - P: Fit<Array2<F>, T::Owned, Error>
+// - type Object = EnsembleLearner<F, E, P::Object, T::Owned>;
+//But this won't compile as it makes 'b unconstrained for some reason
 impl<F: Clone, E, D, T, P: Fit<Array2<F>, T::Owned, Error>>
      Fit<ArrayBase<D, Ix2>, T, Error> for EnsembleLearnerParams<F, E, P>
 where

--- a/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/ensemble_learner.rs
@@ -94,37 +94,37 @@ where
     }
 }
 
-pub struct EnsembleLearnerParams<F, E, P> {
+pub struct EnsembleLearnerParams<F, P> {
     pub ensemble_size: usize,
     pub bootstrap_proportion: f64,
     pub model_params: Option<P>,
-    _t: PhantomData<(F, E)>
+    _t: PhantomData<F>,
 
 }
 
-impl<F, E, P> EnsembleLearnerParams<F, E, P> {
-    pub fn new() -> EnsembleLearnerParams<F, E, P> {
+impl<F, P> EnsembleLearnerParams<F, P> {
+    pub fn new() -> EnsembleLearnerParams<F, P> {
         EnsembleLearnerParams {ensemble_size: 1, bootstrap_proportion: 1.0, model_params: None, _t: PhantomData}
     }
 
-    pub fn ensemble_size(&mut self, size: usize) -> &mut EnsembleLearnerParams<F, E, P> {
+    pub fn ensemble_size(&mut self, size: usize) -> &mut EnsembleLearnerParams<F, P> {
         self.ensemble_size = size;
         self
     }
 
-    pub fn bootstrap_proportion(&mut self, proportion: f64) -> &mut EnsembleLearnerParams<F, E, P> {
+    pub fn bootstrap_proportion(&mut self, proportion: f64) -> &mut EnsembleLearnerParams<F, P> {
         self.bootstrap_proportion = proportion;
         self
     }
 
-    pub fn model_params(&mut self, params: P) -> &mut EnsembleLearnerParams<F, E, P>  {
+    pub fn model_params(&mut self, params: P) -> &mut EnsembleLearnerParams<F, P>  {
         self.model_params = Some(params);
         self
     }
 }
 
 impl<F: Clone, D, T, P: Fit<Array2<F>, T::Owned, Error>>
-     Fit<ArrayBase<D, Ix2>, T, Error> for EnsembleLearnerParams<F, <T as AsTargets>::Elem, P>
+     Fit<ArrayBase<D, Ix2>, T, Error> for EnsembleLearnerParams<F, P>
 where
     D: Data<Elem = F> ,
     T: AsTargets + FromTargetArrayOwned<<T as AsTargets>::Elem>,

--- a/algorithms/linfa-ensemble/src/ensemble/mod.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/mod.rs
@@ -1,0 +1,6 @@
+mod ensemble_learner;
+mod random_forest;
+
+pub use ensemble_learner::*;
+pub use random_forest::*;
+

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -43,7 +43,7 @@ pub fn rf_test() {
     let ranked_predictions_ensemble = model.aggregate_predictions(predictions_ensemble);
 
     //println!("Predictions: \n{:?}", predictions_ensemble);
-    println!("Ranked Predictions: \n{:?}", ranked_predictions_ensemble);
+    println!("Ranked Predictions: \n{:?}", ranked_predictions_ensemble.collect::<Vec<_>>());
 
     let mut y_array: Array2<usize> = model.default_target(&dataset.records);
 

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -1,0 +1,54 @@
+use super::{EnsembleLearner, EnsembleLearnerParams};
+use ndarray::{Array1, Array, Array2, OwnedRepr, Axis};
+use linfa::{Dataset};
+use linfa::prelude::{Predict, PredictInplace, Fit};
+use linfa_trees::{DecisionTree, DecisionTreeParams};
+use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
+use rand::rngs::SmallRng;
+
+
+pub type RandomForestParams<F, L> = EnsembleLearnerParams<F, L, DecisionTreeParams<F, L>>;
+pub type RandomForest<F, L> = EnsembleLearner<F, L, DecisionTree<F, L>, Array2<L>>;
+
+pub fn rf_test() {
+
+    let num_samples = 3;
+    let num_features = 5;
+    let mut rng = SmallRng::seed_from_u64(42);
+
+    println!("Creating Data");
+    let data = Array::random_using((num_samples, num_features), Uniform::new(-1., 1.), &mut rng);
+    let targets = (0..num_samples).collect::<Array1<usize>>();
+    let dataset = Dataset::new(data, targets);
+
+    println!("Fitting Tree as baseline");
+    let tree_params: DecisionTreeParams<f64, usize> = DecisionTree::params();
+    let tree_model = tree_params.fit(&dataset).unwrap();
+
+
+    println!("Creating Ensemble");
+    let dt: DecisionTreeParams<f64, usize> = DecisionTree::params();
+    let mut learner: RandomForestParams<f64, usize> = EnsembleLearnerParams::new();
+    learner.ensemble_size(5).bootstrap_proportion(0.6).model_params(dt);
+
+    println!("Fitting Ensemble Model");
+    let model = learner.fit(&dataset).unwrap();
+
+
+    println!("Creating Prediction Data");
+    let data = Array::random_using((num_samples, num_features), Uniform::new(-1., 1.), &mut rng);
+    println!("Predicting");
+    let predictions_tree: Array1<usize> = tree_model.predict(&data);
+    
+    let predictions_ensemble = model.generate_predictions(&data);
+    let ranked_predictions_ensemble = model.aggregate_predictions(predictions_ensemble);
+
+    //println!("Predictions: \n{:?}", predictions_ensemble);
+    println!("Ranked Predictions: \n{:?}", ranked_predictions_ensemble);
+
+    let mut y_array = model.default_target(&dataset.records);
+
+
+    let final_predictions_ensemble = model.predict(&dataset);
+    println!("Final Predictions: \n{:?}", final_predictions_ensemble);
+}

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -39,7 +39,7 @@ pub fn rf_test() {
     let data = Array::random_using((num_samples, num_features), Uniform::new(-1., 1.), &mut rng);
     println!("Predicting");
     let predictions_tree: Array1<usize> = tree_model.predict(&data);
-    
+
     let predictions_ensemble = model.generate_predictions(&data);
     let ranked_predictions_ensemble = model.aggregate_predictions(predictions_ensemble);
 

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -8,7 +8,7 @@ use rand::rngs::SmallRng;
 
 
 pub type RandomForestParams<F, L> = EnsembleLearnerParams<F, DecisionTreeParams<F, L>>;
-pub type RandomForest<F, L> = EnsembleLearner<F, L, DecisionTree<F, L>, Array2<L>>;
+pub type RandomForest<F, L> = EnsembleLearner<F, DecisionTree<F, L>, Array2<L>>;
 
 pub fn rf_test() {
 

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -7,11 +7,10 @@ use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
 use rand::rngs::SmallRng;
 
 
-pub type RandomForestParams<F, L> = EnsembleLearnerParams<F, DecisionTreeParams<F, L>>;
+pub type RandomForestParams<F, L> = EnsembleLearnerParams<DecisionTreeParams<F, L>>;
 pub type RandomForest<F, L> = EnsembleLearner<F, DecisionTree<F, L>, Array2<L>>;
 
 pub fn rf_test() {
-
     let num_samples = 3;
     let num_features = 5;
     let mut rng = SmallRng::seed_from_u64(42);

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -8,7 +8,7 @@ use rand::rngs::SmallRng;
 
 
 pub type RandomForestParams<F, L> = EnsembleLearnerParams<DecisionTreeParams<F, L>>;
-pub type RandomForest<F, L> = EnsembleLearner<F, DecisionTree<F, L>, Array2<L>>;
+pub type RandomForest<F, L> = EnsembleLearner<DecisionTree<F, L>>;
 
 pub fn rf_test() {
     let num_samples = 3;
@@ -39,15 +39,15 @@ pub fn rf_test() {
     println!("Predicting");
     let predictions_tree: Array1<usize> = tree_model.predict(&data);
 
-    let predictions_ensemble = model.generate_predictions(&data);
+    let predictions_ensemble = model.generate_predictions::<_, Array2<usize>>(&data);
     let ranked_predictions_ensemble = model.aggregate_predictions(predictions_ensemble);
 
     //println!("Predictions: \n{:?}", predictions_ensemble);
     println!("Ranked Predictions: \n{:?}", ranked_predictions_ensemble);
 
-    let mut y_array = model.default_target(&dataset.records);
+    let mut y_array: Array2<usize> = model.default_target(&dataset.records);
 
 
-    let final_predictions_ensemble = model.predict(&dataset);
+    let final_predictions_ensemble: Array2<usize> = model.predict(&dataset);
     println!("Final Predictions: \n{:?}", final_predictions_ensemble);
 }

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -7,7 +7,7 @@ use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
 use rand::rngs::SmallRng;
 
 
-pub type RandomForestParams<F, L> = EnsembleLearnerParams<F, L, DecisionTreeParams<F, L>>;
+pub type RandomForestParams<F, L> = EnsembleLearnerParams<F, DecisionTreeParams<F, L>>;
 pub type RandomForest<F, L> = EnsembleLearner<F, L, DecisionTree<F, L>, Array2<L>>;
 
 pub fn rf_test() {

--- a/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
+++ b/algorithms/linfa-ensemble/src/ensemble/random_forest.rs
@@ -1,5 +1,5 @@
 use super::{EnsembleLearner, EnsembleLearnerParams};
-use ndarray::{Array1, Array, Array2, OwnedRepr, Axis};
+use ndarray::{Array1, Array, Array2};
 use linfa::{Dataset};
 use linfa::prelude::{Predict, PredictInplace, Fit};
 use linfa_trees::{DecisionTree, DecisionTreeParams};

--- a/algorithms/linfa-ensemble/src/examples/rf_test.rs
+++ b/algorithms/linfa-ensemble/src/examples/rf_test.rs
@@ -1,0 +1,6 @@
+use super::ensemble_learner;
+use super::random_forest;
+
+fn main() -> Result<()> {
+    rf_test();
+}

--- a/algorithms/linfa-ensemble/src/lib.rs
+++ b/algorithms/linfa-ensemble/src/lib.rs
@@ -1,0 +1,3 @@
+mod ensemble;
+
+pub use ensemble::*;

--- a/algorithms/linfa-ensemble/src/main.rs
+++ b/algorithms/linfa-ensemble/src/main.rs
@@ -1,0 +1,5 @@
+use linfa_ensemble::*;
+
+fn main() {
+    rf_test();
+}

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -429,10 +429,10 @@ where
     }
 }
 
-impl<'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'b, 'c: 'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = E> + FromTargetArray<'b, E>,
+    T: AsTargets<Elem = E> + FromTargetArray<'c, E>,
     T::Owned: AsTargets,
 {
     /// Apply bootstrapping for samples and features
@@ -455,7 +455,7 @@ where
         &'b self,
         sample_feature_size: (usize, usize),
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
@@ -496,7 +496,7 @@ where
         &'b self,
         num_samples: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
@@ -531,7 +531,7 @@ where
         &'b self,
         num_features: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             let targets = T::new_targets(self.as_multi_targets().to_owned());

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -2,7 +2,7 @@ use super::{
     super::traits::{Predict, PredictInplace},
     iter::{ChunksIter, DatasetIter, Iter},
     AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView, Float,
-    FromTargetArray, Label, Labels, Records, Result,
+    FromTargetArray, FromTargetArrayOwned, Label, Labels, Records, Result,
 };
 use crate::traits::Fit;
 use ndarray::{
@@ -429,10 +429,10 @@ where
     }
 }
 
-impl<'b, 'c: 'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = E> + FromTargetArray<'c, E>,
+    T: AsTargets<Elem = E> + FromTargetArrayOwned<E>,
     T::Owned: AsTargets,
 {
     /// Apply bootstrapping for samples and features
@@ -455,7 +455,7 @@ where
         &'b self,
         sample_feature_size: (usize, usize),
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArrayOwned<E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
@@ -496,7 +496,7 @@ where
         &'b self,
         num_samples: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArrayOwned<E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
@@ -531,7 +531,7 @@ where
         &'b self,
         num_features: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'c, E>>::Owned>> + 'b
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArrayOwned<E>>::Owned>> + 'b
     {
         std::iter::repeat(()).map(move |_| {
             let targets = T::new_targets(self.as_multi_targets().to_owned());
@@ -594,13 +594,13 @@ where
     /// let dataset : DatasetView<f64, usize> = (records.view(), targets.view()).into();
     /// let accuracies = dataset.fold(3).into_iter().map(|(train, valid)| {
     ///     // Here you can train your model and perform validation
-    ///     
+    ///
     ///     // let model = params.fit(&dataset);
     ///     // let predi = model.predict(&valid);
-    ///     // predi.confusion_matrix(&valid).accuracy()  
+    ///     // predi.confusion_matrix(&valid).accuracy()
     /// });
     /// ```
-    ///  
+    ///
     pub fn fold(
         &self,
         k: usize,
@@ -1002,7 +1002,7 @@ impl<F, E> Dataset<F, E> {
     /// * `ratio`: the ratio of samples in the input Dataset to include in the first output one
     ///
     /// ### Returns
-    ///  
+    ///
     /// The input Dataset split into two according to the input ratio.
     pub fn split_with_ratio(mut self, ratio: f32) -> (Self, Self) {
         let (nfeatures, ntargets) = (self.nfeatures(), self.ntargets());

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -17,6 +17,19 @@ impl<'a, L, S: Data<Elem = L>> AsTargets for ArrayBase<S, Ix1> {
     }
 }
 
+// impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix1> {
+//     type Owned = ArrayBase<OwnedRepr<L>, Ix1>;
+//     type View = ArrayBase<ViewRepr<&'a L>, Ix1>;
+
+//     fn new_targets(targets: Array2<L>) -> Self::Owned {
+//         targets.index_axis(Axis(1), 0).to_owned()
+//     }
+
+//     fn new_targets_view(targets: ArrayView2<'a, L>) -> Self::View {
+//         targets.index_axis(Axis(1), 0)
+//     }
+// }
+
 impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix2> {
     type Owned = ArrayBase<OwnedRepr<L>, Ix2>;
     type View = ArrayBase<ViewRepr<&'a L>, Ix2>;

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -222,17 +222,18 @@ pub trait AsTargets {
     }
 }
 
+pub trait FromTargetArrayOwned<F> {
+    type Owned;
+    fn new_targets(targets: Array2<F>) -> Self::Owned;
+}
+
 /// Helper trait to construct counted labels
 ///
 /// This is implemented for objects which can act as targets and created from a target matrix. For
 /// targets represented as `ndarray` matrix this is identity, for counted labels, i.e.
 /// `TargetsWithLabels`, it creates the corresponding wrapper struct.
-pub trait FromTargetArray<'a, F> {
-    type Owned;
+pub trait FromTargetArray<'a, F>: FromTargetArrayOwned<F> {
     type View;
-
-    /// Create self object from new target array
-    fn new_targets(targets: Array2<F>) -> Self::Owned;
     fn new_targets_view(targets: ArrayView2<'a, F>) -> Self::View;
 }
 


### PR DESCRIPTION
# Add ensemble learners algorithm

- split the owned part of `FromTargetArray` into `FromTargetArrayOwned` to avoid having to restrict a ilfetime in the `PredictInplace` implementation
- remove some unnecessary type/lifetime parameters

